### PR TITLE
Avoid duplicate resource for install directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2016-02-xx - Release 3.2.0
+
+### Summary
+
+- Provide param to disable managing the 'installdir' (@Etherdaemon PR #4)
+- Provide param to disable managing the 'appdir' (@Etherdaemon PR #4)
+- Provide param to specify a custom 'appdir' (@Etherdaemon PR #4)
+
 ## 2015-11-17 - Release 3.1.2
 
 ### Summary

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,7 @@
 Brett Porter <brett@maestrodev.com>
 Carlos Sanchez <github@carlossanchez.eu>
 David Castro <dcastro@mediatemple.net>
+Etherdaemon <kaz.cheng@gmail.com>
 James Dumay <james.w.dumay@gmail.com>
 Josh Beard <josh@signalboxes.net>
 Simon Croome <simon@croome.org>

--- a/README.md
+++ b/README.md
@@ -179,9 +179,34 @@ Default: '/usr/local/bamboo'
 The base directory for extracting/installing Bamboo to.  Note that it will
 decompress _inside_ this directory to a directory such as
 `atlassian-bamboo-5.9.7/`  So an `installdir` of `/usr/local/bamboo` will
-ultimately install Bamboo to `/usr/local/bamboo/atlassian-bamboo-5.9.7/`
+ultimately install Bamboo to `/usr/local/bamboo/atlassian-bamboo-5.9.7/` by
+default.
 
-Note that the `installdir` is managed by this module.
+Refer to `manage_installdir` and `appdir`
+
+##### `manage_installdir`
+
+Default: `true`
+
+Boolean.  Whether this module should be responsible for managing the
+`installdir`
+
+##### `appdir`
+
+Default: `${installdir}/atlassian-bamboo-${version}`
+
+This is the directory that Bamboo gets extracted to within the 'installdir'
+
+By default, this is a subdirectory with the specific version appended to it.
+
+You might want to customize this if you don't want to use the default
+`atlassian-bamboo-${version}` convention.
+
+##### `manage_appdir`
+
+Default: `true`
+
+Boolean.  Whether this module should be responsible for managing the `appdir`
 
 ##### `homedir`
 

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -1,6 +1,6 @@
 class bamboo::configure (
   $version            = $bamboo::version,
-  $app_dir            = $bamboo::app_dir,
+  $appdir             = $bamboo::real_appdir,
   $homedir            = $bamboo::homedir,
   $user               = $bamboo::user,
   $group              = $bamboo::group,
@@ -19,7 +19,7 @@ class bamboo::configure (
   $accept_count       = $bamboo::accept_count,
 ) {
 
-  file { "${app_dir}/bin/setenv.sh":
+  file { "${appdir}/bin/setenv.sh":
     ensure  => 'file',
     owner   => $user,
     group   => $group,
@@ -27,7 +27,7 @@ class bamboo::configure (
     content => template('bamboo/setenv.sh.erb'),
   }
 
-  file { "${app_dir}/atlassian-bamboo/WEB-INF/classes/bamboo-init.properties":
+  file { "${appdir}/atlassian-bamboo/WEB-INF/classes/bamboo-init.properties":
     ensure  => 'file',
     owner   => $user,
     group   => $group,
@@ -52,9 +52,9 @@ class bamboo::configure (
     $_changes = $changes
   }
 
-  augeas { "${app_dir}/conf/server.xml":
+  augeas { "${appdir}/conf/server.xml":
     lens    => 'Xml.lns',
-    incl    => "${app_dir}/conf/server.xml",
+    incl    => "${appdir}/conf/server.xml",
     changes => $_changes,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,10 @@
 class bamboo (
   $version            = '5.9.7',
   $extension          = 'tar.gz',
+  $manage_installdir  = true,
   $installdir         = '/usr/local/bamboo',
+  $manage_appdir      = true,
+  $appdir             = undef,
   $homedir            = '/var/local/bamboo',
   $context_path       = '',
   $tomcat_port        = '8085',
@@ -83,7 +86,13 @@ class bamboo (
 
   validate_integer($shutdown_wait)
 
-  $app_dir = "${installdir}/atlassian-bamboo-${version}"
+  if $appdir == undef or $appdir == '' {
+    $app_dir = "${installdir}/atlassian-bamboo-${version}"
+  }
+  else {
+    validate_string($app_dir)
+    $app_dir = $app_dir
+  }
 
   anchor { 'bamboo::start': } ->
   class { 'bamboo::install': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,11 +87,11 @@ class bamboo (
   validate_integer($shutdown_wait)
 
   if $appdir == undef or $appdir == '' {
-    $app_dir = "${installdir}/atlassian-bamboo-${version}"
+    $real_appdir = "${installdir}/atlassian-bamboo-${version}"
   }
   else {
-    validate_string($app_dir)
-    $app_dir = $app_dir
+    validate_absolute_path($appdir)
+    $real_appdir = $appdir
   }
 
   anchor { 'bamboo::start': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class bamboo::install (
   $download_url       = $bamboo::download_url,
   $installdir         = $bamboo::installdir,
   $version            = $bamboo::version,
-  $app_dir            = $bamboo::app_dir,
+  $appdir             = $bamboo::real_appdir,
   $extension          = $bamboo::extension,
   $manage_user        = $bamboo::manage_user,
   $manage_group       = $bamboo::manage_group,
@@ -50,10 +50,11 @@ class bamboo::install (
   }
 
   if $manage_appdir {
-    file { $app_dir:
+    file { $appdir:
       ensure => 'directory',
       owner  => $user,
       group  => $group,
+      before => Staging::File[$file],
     }
   }
 
@@ -67,12 +68,11 @@ class bamboo::install (
   staging::file { $file:
     source  => "${download_url}/${file}",
     timeout => '1800',
-    require => File[$app_dir],
   }
 
   staging::extract { $file:
-    target  => $app_dir,
-    creates => "${app_dir}/conf",
+    target  => $appdir,
+    creates => "${appdir}/conf",
     strip   => 1,
     user    => $user,
     group   => $group,
@@ -85,9 +85,9 @@ class bamboo::install (
     group  => $group,
   }
 
-  exec { "chown_${app_dir}":
-    command => "chown -R ${user}:${group} ${app_dir}",
-    unless  => "find ${app_dir} ! -type l \\( ! -user ${user} \\) -o \\( ! -group ${group} \\) | wc -l | awk '{print \$1}' | grep -qE '^0'",
+  exec { "chown_${appdir}":
+    command => "chown -R ${user}:${group} ${appdir}",
+    unless  => "find ${appdir} ! -type l \\( ! -user ${user} \\) -o \\( ! -group ${group} \\) | wc -l | awk '{print \$1}' | grep -qE '^0'",
     path    => '/bin:/usr/bin',
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,10 +39,12 @@ class bamboo::install (
     }
   }
 
-  file { $installdir:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
+  if ! defined (File[$installdir]) {
+    file { $installdir:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
   }
 
   file { $app_dir:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,18 +1,20 @@
 class bamboo::install (
-  $user         = $bamboo::user,
-  $group        = $bamboo::group,
-  $uid          = $bamboo::uid,
-  $gid          = $bamboo::gid,
-  $password     = $bamboo::password,
-  $homedir      = $bamboo::homedir,
-  $shell        = $bamboo::shell,
-  $download_url = $bamboo::download_url,
-  $installdir   = $bamboo::installdir,
-  $version      = $bamboo::version,
-  $app_dir      = $bamboo::app_dir,
-  $extension    = $bamboo::extension,
-  $manage_user  = $bamboo::manage_user,
-  $manage_group = $bamboo::manage_group,
+  $user               = $bamboo::user,
+  $group              = $bamboo::group,
+  $uid                = $bamboo::uid,
+  $gid                = $bamboo::gid,
+  $password           = $bamboo::password,
+  $homedir            = $bamboo::homedir,
+  $shell              = $bamboo::shell,
+  $download_url       = $bamboo::download_url,
+  $installdir         = $bamboo::installdir,
+  $version            = $bamboo::version,
+  $app_dir            = $bamboo::app_dir,
+  $extension          = $bamboo::extension,
+  $manage_user        = $bamboo::manage_user,
+  $manage_group       = $bamboo::manage_group,
+  $manage_installdir  = $bamboo::manage_installdir,
+  $manage_appdir      = $bamboo::manage_appdir,
 ) {
 
   $file    = "atlassian-bamboo-${version}.${extension}"
@@ -39,7 +41,7 @@ class bamboo::install (
     }
   }
 
-  if ! defined (File[$installdir]) {
+  if $manage_installdir {
     file { $installdir:
       ensure => 'directory',
       owner  => $user,
@@ -47,10 +49,12 @@ class bamboo::install (
     }
   }
 
-  file { $app_dir:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
+  if $manage_appdir {
+    file { $app_dir:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
   }
 
   file { $homedir:

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,6 @@
 class bamboo::service (
   $version          = $bamboo::version,
-  $app_dir          = $bamboo::app_dir,
+  $appdir           = $bamboo::real_appdir,
   $user             = $bamboo::user,
   $shell            = $bamboo::shell,
   $java_home        = $bamboo::java_home,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "joshbeard-bamboo",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "author": "joshbeard",
   "summary": "Manages the installation of Atlassian Bamboo",
   "license": "Apache-2.0",

--- a/templates/bamboo.init.erb
+++ b/templates/bamboo.init.erb
@@ -16,7 +16,7 @@ SERVICE=bamboo
 USER=<%= @user %>
 SHELL=<%= @shell %>
 export JAVA_HOME=<%= @java_home %>
-export CATALINA_HOME=<%= @app_dir %>
+export CATALINA_HOME=<%= @appdir %>
 SHUTDOWN_WAIT=<%= @shutdown_wait %>
 
 
@@ -38,7 +38,7 @@ function stop() {
   pid=$(bamboo_pid)
   if [ -n "$pid" ]; then
     echo -n $"Stopping down $SERVICE: "
-    /bin/su -s $SHELL -m $USER -c "<%= @app_dir %>/bin/stop-bamboo.sh"
+    /bin/su -s $SHELL -m $USER -c "<%= @appdir %>/bin/stop-bamboo.sh"
 
     echo -n "Waiting ${SHUTDOWN_WAIT} seconds for processes to exit "
     let kwait=$SHUTDOWN_WAIT
@@ -69,7 +69,7 @@ function start() {
     exit 1
   else
     echo -n $"Starting $SERVICE: "
-    /bin/su -s $SHELL -m $USER -c "<%= @app_dir %>/bin/start-bamboo.sh"
+    /bin/su -s $SHELL -m $USER -c "<%= @appdir %>/bin/start-bamboo.sh"
     RETVAL=$?
     echo
     return $RETVAL

--- a/templates/bamboo.service.erb
+++ b/templates/bamboo.service.erb
@@ -5,10 +5,10 @@ After=syslog.target network.target
 [Service]
 Type=forking
 Environment="JAVA_HOME=<%= @java_home %>"
-PIDFile=<%= @app_dir %>/work/catalina.pid
+PIDFile=<%= @appdir %>/work/catalina.pid
 User=<%= @user %>
-ExecStart=<%= @app_dir %>/bin/start-bamboo.sh
-ExecStop=<%= @app_dir %>/bin/stop-bamboo.sh
+ExecStart=<%= @appdir %>/bin/start-bamboo.sh
+ExecStop=<%= @appdir %>/bin/stop-bamboo.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -26,7 +26,7 @@ JVM_REQUIRED_ARGS=""
 #
 # Set the catalina PID file location
 #
-CATALINA_PID="<%= @app_dir %>/work/catalina.pid"
+CATALINA_PID="<%= @appdir %>/work/catalina.pid"
 
 #-----------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Hi @joshbeard,

Firstly thank you for this module. So far it's been working fabulously.

May I propose the following PR to allow users to create their own install directories in other manifests?

My own use case is that I want my install directory to be /opt/bamboo but I need it to be a link to /mnt/ebs_data which means I need to manage that particular directory myself.

Cheers.
