### PR TITLE
fix version check to allow for point releases

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@ class bamboo (
   $shutdown_wait      = '20',
 ) inherits bamboo::params {
 
-  validate_re($version, '^\d+\.\d+.\d+$')
+  validate_re($version, ['^\d+\.\d+\.\d+$', '^\d+\.\d+\.\d+\.\d+$'])
   validate_re($extension, '^(tar\.gz|\.zip)$')
   validate_absolute_path($installdir)
   validate_absolute_path($homedir)


### PR DESCRIPTION
Currently the version validation function is set to check against standard semver, but Atlassian occasionally does point releases (as is currently the case with `5.12.2.1`).
