### PR TITLE
add sysconfig file for bamboo service

### DIFF
--- a/templates/bamboo.init.erb
+++ b/templates/bamboo.init.erb
@@ -19,6 +19,9 @@ export JAVA_HOME=<%= @java_home %>
 export CATALINA_HOME=<%= @appdir %>
 SHUTDOWN_WAIT=<%= @shutdown_wait %>
 
+if [ -f /etc/sysconfig/bamboo ]; then
+    . /etc/sysconfig/bamboo
+fi
 
 function restart() {
   stop


### PR DESCRIPTION
This would enable to pass environment variable to the bamboo service.

but /etc/sysconfig is a bit redhat specific ? maybe need to add /etc/default for debian users
