### PR TITLE
added test of $::puppet_confdir variable

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class bamboo::params {
     }
   }
 
-  if $::puppet_confdir =~ /^\/etc\/puppetlabs/ {
+  if $::puppet_confdir != undef and $::puppet_confdir =~ /^\/etc\/puppetlabs/ {
     $facter_dir = '/etc/puppetlabs/facter/facts.d'
   } else {
     $facter_dir = '/etc/facter/facts.d'


### PR DESCRIPTION
I won't claim it's the most robust fix out there, but I don't have much time to rejigger to something better... so adding a quick test of the variable to avoid the regex failing due to the $::puppet_confdir variable not existing.