### PR TITLE
Specific Augeas path to connector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   allow_failures:
     - env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/ubuntu-18.04 BEAKER_TESTMODE=apply
     - env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/debian-9 BEAKER_TESTMODE=apply
+    - env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_set=docker/debian-8 BEAKER_TESTMODE=apply
   include:
     -
       bundler_args:
@@ -85,10 +86,10 @@ matrix:
       env: CHECK=parallel_spec
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.4
+      rvm: 2.4.6
     -
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
-      rvm: 2.1.9
+      rvm: 2.4.6
 #branches:
 #  only:
 #    - master

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -44,7 +44,7 @@ class bamboo::configure (
   ]
 
   if !empty($proxy) {
-    $_proxy   = suffix(prefix(join_keys_to_values($proxy, " '"), 'set Server/Service/Connector/#attribute/'), "'")
+    $_proxy   = suffix(prefix(join_keys_to_values($proxy, " '"), 'set Server/Service/Connector[#attribute/protocol = "HTTP/1.1"]/#attribute/'), "'")
     $_changes = concat($changes, $_proxy)
   }
   else {

--- a/spec/classes/configure_spec.rb
+++ b/spec/classes/configure_spec.rb
@@ -93,9 +93,9 @@ describe 'bamboo' do
                 "set Server/Service/Connector/#attribute/connectionTimeout '30000'",
                 "set Server/Service/Connector/#attribute/port '9090'",
                 "set Server/Service/Connector/#attribute/acceptCount '200'",
-                "set Server/Service/Connector/#attribute/scheme 'https'",
-                "set Server/Service/Connector/#attribute/proxyName 'bamboo.example.com'",
-                "set Server/Service/Connector/#attribute/proxyPort '443'",
+                "set Server/Service/Connector[#attribute/protocol = \"HTTP/1.1\"]/#attribute/scheme 'https'",
+                "set Server/Service/Connector[#attribute/protocol = \"HTTP/1.1\"]/#attribute/proxyName 'bamboo.example.com'",
+                "set Server/Service/Connector[#attribute/protocol = \"HTTP/1.1\"]/#attribute/proxyPort '443'",
               ],
             )
           end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -50,7 +50,7 @@ RSpec.configure do |c|
         end
 
         if fact_on(host, 'operatingsystemmajrelease') == '8'
-          on host, 'echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list'
+          on host, 'echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list'
         end
 
         on host, 'apt-get update'


### PR DESCRIPTION
Use a more specific path for Augeas for setting the proxy attributes on
the connector in server.xml.

This fixes an issue with Bamboo > 6.8 where they've enabled a second
connector in server.xml.

Tests: allow failed debian 8, update ruby

* Allow the debian 8 acceptance tests to fail due to package repo.
* Update rvm/ruby in tests.